### PR TITLE
Fix for UE4 rotator

### DIFF
--- a/Plugins/HydraPlugin/Source/HydraPlugin/Private/FHydraPlugin.cpp
+++ b/Plugins/HydraPlugin/Source/HydraPlugin/Private/FHydraPlugin.cpp
@@ -49,7 +49,8 @@ public:
 
 		//converted.position = FVector(data->pos[0], data->pos[1], data->pos[2]);
 		converted.position = FVector(-data->pos[2], data->pos[0], data->pos[1]);	//NB: sixense axis is different to unreal
-		converted.rotation = FQuat(data->rot_quat[0], data->rot_quat[1], data->rot_quat[2], data->rot_quat[3]);
+		//converted.rotation = FQuat(data->rot_quat[0], data->rot_quat[1], data->rot_quat[2], data->rot_quat[3]);
+		converted.rotation = FQuat(data->rot_quat[2], -data->rot_quat[0], -data->rot_quat[1], data->rot_quat[3]); //NB: sixense rotation is different to unreal
 		converted.joystick = FVector2D(data->joystick_x, data->joystick_y);
 		converted.trigger = data->trigger;
 		converted.buttons = data->buttons;


### PR DESCRIPTION
This change will invert and set the axis values in the correct order so you do not have to rotate them manually for UE4.
